### PR TITLE
Implement a Docker Multistage stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ COPY . .
 RUN pip3 install --no-cache-dir torch==1.6.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+ENTRYPOINT /usr/src/app/run.sh
+
 FROM debian:stable-slim
 
+RUN addgroup --gid 1001 pulse
 RUN addgroup --gid 1000 ml \
  && adduser --gecos "" \
       --home /usr/src/app \
@@ -33,8 +36,9 @@ RUN addgroup --gid 1000 ml \
       ml \
  && adduser ml adm \
  && adduser ml audio \
-# && adduser ml pulse \
+ && adduser ml pulse \
  && adduser ml voice
+
 
 COPY --from=builder /usr/src/app .
 
@@ -51,4 +55,3 @@ COPY --chown=ml:ml . .
 
 EXPOSE 8080
 
-ENTRYPOINT /usr/src/app/run.sh

--- a/audio_model/audio_model/config/config.py
+++ b/audio_model/audio_model/config/config.py
@@ -65,16 +65,16 @@ DO_NOT_INCLUDE = [
 ]
 
 
-# class DataDirectory:
-#     DATA_DIR = r"C:\Users\ander\Documents\common-voice-data"
-#     DEV_DIR = r"C:\Users\ander\Documents\common-voice-dev"
-#     CLIPS_DIR = r"C:\Users\ander\Documents\common-voice-data\clips"
-
-
 class DataDirectory:
-    DATA_DIR = "/home/jupyter/comm-voice-training/common-voice-data"
-    DEV_DIR = "/home/jupyter/comm-voice-training/common-voice-dev"
-    CLIPS_DIR = "/home/jupyter/comm-voice-training/common-voice-data/clips"
+    DATA_DIR = r"C:\Users\ander\Documents\common-voice-data"
+    DEV_DIR = r"C:\Users\ander\Documents\common-voice-dev"
+    CLIPS_DIR = r"C:\Users\ander\Documents\common-voice-data\clips"
+
+
+# class DataDirectory:
+#     DATA_DIR = "/home/jupyter/comm-voice-training/common-voice-data"
+#     DEV_DIR = "/home/jupyter/comm-voice-training/common-voice-dev"
+#     CLIPS_DIR = "/home/jupyter/comm-voice-training/common-voice-data/clips"
 
 class TrainingTestingSplitDirectory:
     TRAIN_DIR = r"train_data"

--- a/audio_model/audio_model/utils.py
+++ b/audio_model/audio_model/utils.py
@@ -135,8 +135,11 @@ def sample_weight(data_folder):
     return sampler
 
 
-def audio_melspectrogram(signal, sample_rate=CommonVoiceModels.Frame.FRAME['SAMPLE_RATE'],
-                         n_mels=CommonVoiceModels.Frame.FRAME['N_MELS'], fmax=CommonVoiceModels.Frame.FRAME['FMAX']):
+FRAME = CommonVoiceModels.Frame.FRAME
+
+
+def audio_melspectrogram(signal, sample_rate=FRAME['SAMPLE_RATE'],
+                         n_mels=FRAME['N_MELS'], fmax=FRAME['FMAX']):
     specto = melspectrogram(y=signal, sr=sample_rate, n_mels=n_mels,
                             fmax=fmax)
     spec_to_db = power_to_db(specto, ref=np.max)
@@ -193,11 +196,14 @@ def log_scalar(name, value, step):
     wandb.log({name: value}, step=step)
 
 
+max_workers = concurrent.futures.ProcessPoolExecutor()._max_workers
+
+
 def run_thread_pool(function, my_iter):
-    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrent.futures.ProcessPoolExecutor()._max_workers) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         tqdm(executor.map(function, my_iter), total=len(my_iter))
 
 
 def run_process_pool(function, my_iter):
-    with concurrent.futures.ProcessPoolExecutor(max_workers=concurrent.futures.ProcessPoolExecutor()._max_workers) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
         tqdm(executor.map(function, my_iter), total=len(my_iter))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   commvoice:
     build: .
-    image: anelso42/common-voice-app
+    image: anelso42/common-voice
     container_name: commvoice
     devices:
       - /dev/snd
@@ -17,7 +17,7 @@ services:
     volumes:
       - $HOME/.config/pulse:/usr/src/app/.config/pulse
 #      - /etc/machine-id:/etc/machine-id:ro
-      - /run/user/1000/pulse:/run/user/1000/pulse:ro
+      - /run/user/1001/pulse:/run/user/1001/pulse:ro
 
     ports:
       - 8080:${PORT:-8080}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,13 @@ services:
     networks:
       - my-network
     environment:
-#      - ALSA_PCM=usbstream:CARD=StargazerMicrop
+      - ALSA_PCM=usbstream:CARD=StargazerMicrop
       - PORT=${PORT:-8080}
       - XDG_RUNTIME_DIR=/run/user/1000
       - ALSA_CARD=Generic
     volumes:
       - $HOME/.config/pulse:/usr/src/app/.config/pulse
-#      - /etc/machine-id:/etc/machine-id:ro
+      - /etc/machine-id:/etc/machine-id:ro
       - /run/user/1001/pulse:/run/user/1001/pulse:ro
 
     ports:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19.3
+FROM nginx:1.19.3-alpine-perl
 
 RUN rm /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Reference #147 

Attempted to implement an alpine base image to reduce the build size. see below: The below configuration required hours of in-depth research.  Alpine images don't install the whl and require you to manually add each dependency. The below image took more than 30 minutes to build. 

Final image size 89 MB. down from 1.4 GB

````
FROM python:3.7.9-alpine3.12 AS builder

ARG DEBIAN_FRONTEND=noninteractive

WORKDIR /usr/src/app

RUN apk add --no-cache ffmpeg \
    portaudio \
    portaudio-dev \
    libsndfile \
    libportaudiocxx \
    libsndfile-dev \
    pulseaudio-ctl \
    musl-dev \
    linux-headers \
    g++ \
    jpeg-dev \
    zlib-dev \
    gfortran \
    build-base\
    freetype-dev \
    libpng-dev \
    openblas-dev \
    cmake


RUN mkdir -p .local/bin .config .cache

COPY . .

RUN pip3 install --no-cache-dir torch==1.6.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html \
  && pip3 install --no-cache-dir torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html \
  && pip3 install --no-cache-dir pyaudio \
  && pip3 install --no-cache-dir -r commonvoice/requirements.txt

COPY --from=builder /usr/src/app .

RUN addgroup -g 1001 -S pulse \
    && addgroup -g 1002 -S voice \
    && addgroup -g 1000 -S ml \
    && adduser -S -D -H -u 1000 -h /usr/src/app -s /bin/bash -G ml -g ml ml \
    && adduser ml adm \
    && adduser ml audio \
    && adduser ml pulse \
    && adduser ml voice \
    && mkdir -p /run/user/1000 \
    && chown ml:ml /run/user/1000

RUN mkdir -p .local/bin .config .cache

RUN mkdir -p /run/user/1000 \
 && chown ml:ml /run/user/1000

USER ml

ENV PATH="/usr/src/app/.local/bin:$PATH"

COPY --chown=ml:ml . .

EXPOSE 8080

ENTRYPOINT /usr/src/app/run.sh
````